### PR TITLE
pypi: add a wildcard explicitly to match submodules

### DIFF
--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -27,4 +27,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where=["."]
-include=["cctrusted_base"]
+include=["cctrusted_base*"]

--- a/vmsdk/python/pyproject.toml
+++ b/vmsdk/python/pyproject.toml
@@ -27,4 +27,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where=["."]
-include=["cctrusted_vm"]
+include=["cctrusted_vm*"]


### PR DESCRIPTION
The directory tdx in cctrusted_base does not build to the package since that parent package is matched by the pattern will not dictate if the submodule will be included or excluded from the distribution. We need to add a wildcard in the pattern to match submodules explicitly.

Reference:
https://setuptools.pypa.io/en/latest/userguide/package_discovery.html