### PR TITLE
pypi: add cctrusted_base as dependency for cctrusted_vm

### DIFF
--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cctrusted_base"
-version = "0.0.3"
+version = "0.3.1"
 authors = [
   { name="Lu, Ken", email="ken.lu@intel.com" },
   { name="Zhang, Wenhui", email="wenhui.zhang@bytedance.com" },

--- a/vmsdk/python/pyproject.toml
+++ b/vmsdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cctrusted_vm"
-version = "0.0.3"
+version = "0.3.1"
 authors = [
   { name="Lu, Ken", email="ken.lu@intel.com" },
   { name="Zhang, Wenhui", email="wenhui.zhang@bytedance.com" },
@@ -15,6 +15,8 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
+  "cctrusted_base",
+  "pytest",
 ]
 
 [project.urls]

--- a/vmsdk/python/requirements.txt
+++ b/vmsdk/python/requirements.txt
@@ -1,1 +1,2 @@
+cctrusted_base
 pytest


### PR DESCRIPTION
Simplify package installation process to set 'cctrusted_base' as dependency for 'cctrusted_vm'