### PR TITLE
vmsdk: align api output with rust implementation

### DIFF
--- a/common/python/cctrusted_base/api.py
+++ b/common/python/cctrusted_base/api.py
@@ -1,12 +1,15 @@
 """
 The CC Trusted API
 """
+import logging
 from abc import ABC, abstractmethod
 # pylint: disable=unused-import
 from cctrusted_base.imr import TcgIMR
-from cctrusted_base.ccreport import CcReport
 from cctrusted_base.eventlog import EventLogs
+from cctrusted_base.ccreport import CcReport
 from cctrusted_base.tcg import TcgAlgorithmRegistry
+
+LOG = logging.getLogger(__name__)
 
 class CCTrustedApi(ABC):
 
@@ -107,7 +110,7 @@ class CCTrustedApi(ABC):
         raise NotImplementedError("Inherited SDK class should implement this.")
 
     @abstractmethod
-    def get_cc_eventlog(self, start:int = None, count:int = None) -> EventLogs:
+    def get_cc_eventlog(self, start:int = None, count:int = None) -> list:
         """Get eventlog for given index and count.
 
         TCG log in Eventlog. Verify to spoof events in the TCG log, hence defeating
@@ -120,25 +123,29 @@ class CCTrustedApi(ABC):
             count(int): the number of event logs to fetch
 
         Returns:
-            ``Eventlogs`` object containing all event logs following TCG PCClient Spec.
+            list of parsed event logs following TCG spec.
         """
         raise NotImplementedError("Inherited SDK class should implement this.")
 
-    @abstractmethod
-    def replay_cc_eventlog(self, event_logs:EventLogs) -> dict:
+    @staticmethod
+    def replay_cc_eventlog(event_logs:list) -> dict:
         """Replay event logs based on data provided.
 
         TCG event logs can be replayed against IMR measurements to prove the integrity of
         the event logs.
 
         Args:
-            event_logs(Eventlogs): the ``Eventlogs`` object to replay
+            event_logs(list): the list of parsed event logs to replay
 
         Returns:
             A dictionary containing the replay result displayed by IMR index and hash algorithm.
             Layer 1 key of the dict is the IMR index, the value is another dict which using the
             hash algorithm as the key and the replayed measurement as value.
             Sample value:
-                { 0: { 12: <measurement_replayed>}}
+                { 0: { 12: <measurement_replayed> } }
         """
-        raise NotImplementedError("Inherited SDK class should implement this.")
+        if event_logs is None or len(event_logs) == 0:
+            LOG.info("No event log provided to replay.")
+            return {}
+
+        return EventLogs.replay(event_logs)

--- a/common/python/cctrusted_base/eventlog.py
+++ b/common/python/cctrusted_base/eventlog.py
@@ -401,9 +401,13 @@ class EventLogs:
                            TcgEventType.IMA_MEASUREMENT_EVENT, digests,
                            event_size, event, extra_info)
 
-    def replay(self) -> dict:
+    @staticmethod
+    def replay(event_logs:list) -> dict:
         """
         Replay event logs by IMR index.
+
+        Args:
+            event_logs(list): a list of parsed event logs to replay
 
         Returns:
             A dictionary containing the replay result displayed by IMR index and hash algorithm. 
@@ -413,7 +417,12 @@ class EventLogs:
                 { 0: { 12: <measurement_replayed>}}
         """
         measurement_dict = {}
-        for event in self._event_logs:
+        for event in event_logs:
+            # Check event format before replay, skip event if using unknown format
+            if not isinstance(event, (TcgImrEvent, TcgPcClientImrEvent)):
+                LOG.error("Event with unknown format. Skip this one...")
+                continue
+
             # Skip EV_NO_ACTION event during replay as
             # it will not result in a digest being extended into a PCR
             if event.event_type == TcgEventType.EV_NO_ACTION:

--- a/vmsdk/python/cctrusted_vm/sdk.py
+++ b/vmsdk/python/cctrusted_vm/sdk.py
@@ -116,7 +116,7 @@ class CCTrustedVmSdk(CCTrustedApi):
         """
         return self._cvm.get_cc_report(nonce, data, extraArgs)
 
-    def get_cc_eventlog(self, start:int = None, count:int = None) -> EventLogs:
+    def get_cc_eventlog(self, start:int = None, count:int = None) -> list:
         """Get eventlog for given index and count.
 
         TCG log in Eventlog. Verify to spoof events in the TCG log, hence defeating
@@ -129,7 +129,7 @@ class CCTrustedVmSdk(CCTrustedApi):
             count(int): the number of event logs to fetch
 
         Returns:
-            ``Eventlogs`` object containing all event logs following TCG PCClient Spec.
+            Parsed event logs following TCG Spec.
         """
         # Re-do the processing to fetch the latest event logs
         self._cvm.process_eventlog()
@@ -139,27 +139,4 @@ class CCTrustedVmSdk(CCTrustedApi):
 
         event_logs.select(start, count)
 
-        return event_logs
-
-    def replay_cc_eventlog(self, event_logs:EventLogs) -> dict:
-        """Replay event logs based on data provided.
-
-        TCG event logs can be replayed against IMR measurements to prove the integrity of
-        the event logs.
-
-        Args:
-            event_logs(Eventlogs): the ``Eventlogs`` object to replay
-
-        Returns:
-            A dictionary containing the replay result displayed by IMR index and hash algorithm. 
-            Layer 1 key of the dict is the IMR index, the value is another dict which using the
-            hash algorithm as the key and the replayed measurement as value.
-            Sample value:
-                { 0: { 12: <measurement_replayed>}}
-        """
-        if event_logs is None:
-            LOG.error("Input event_logs should not be None.")
-            return None
-        replay_res = event_logs.replay()
-
-        return replay_res
+        return event_logs.event_logs


### PR DESCRIPTION
* change the output of get_cc_eventlog to a list
* change the internal replay function as staticmethod
* change the replay api as staticmethod