### PR TITLE
vmsdk/python: set logging for td_report_cli.py

### DIFF
--- a/vmsdk/python/td_report_cli.py
+++ b/vmsdk/python/td_report_cli.py
@@ -10,7 +10,7 @@ from cctrusted_vm.tdx import CCTrustedTdvmSdk
 
 LOG = logging.getLogger(__name__)
 
-logging.basicConfig(level=logging.NOTSET, format='%(message)s')
+logging.basicConfig(level=logging.NOTSET, format="%(name)s %(levelname)-8s %(message)s")
 
 def main():
     """Example to call get_tdreport and dump the result to stdout."""


### PR DESCRIPTION
The logging config should be consistent with other cli.