### PR TITLE
ccnpsdk: Remove the directory of ccnpsdk

### DIFF
--- a/ccnpsdk/README.md
+++ b/ccnpsdk/README.md
@@ -1,4 +1,0 @@
-# Cloud Native SDK
-
-It is has been implemented at <https://github.com/intel/confidential-cloud-native-primitives/>,
-will migrated to here in future.


### PR DESCRIPTION
A new project is already created at https://github.com/cc-api/confidential-cloud-native-primitives, so we do not need the directory of ccnpsdk.