### PR TITLE
vmsdk/python: fix some issue of quote.

### DIFF
--- a/vmsdk/python/cctrusted_vm/cvm.py
+++ b/vmsdk/python/cctrusted_vm/cvm.py
@@ -119,9 +119,9 @@ class ConfidentialVM:
 
     @abstractmethod
     def get_cc_report(self, nonce: bytearray, data: bytearray, extraArgs) -> CcReport:
-        """Get the quote for given nonce and data.
+        """Get the CcReport (i.e. quote) for given nonce and data.
 
-        The quote is signing of attestation data (IMR values or hashes of IMR
+        The CcReport is signing of attestation data (IMR values or hashes of IMR
         values), made by a trusted foundation (TPM) using a key trusted by the
         verifier.
 
@@ -133,7 +133,7 @@ class ConfidentialVM:
             extraArgs: for TPM, it will be given list of IMR/PCRs
 
         Returns:
-            The ``Quote`` object.
+            The ``CcReport`` object.
         """
         raise NotImplementedError("Should be implemented by inherited class")
 
@@ -348,7 +348,7 @@ class TdxVM(ConfidentialVM):
 
 
     def get_cc_report(self, nonce: bytearray, data: bytearray, extraArgs) -> CcReport:
-        """Get quote.
+        """Get CcReport (i.e. TD Quote in the context of TDX).
 
         This depends on Quote Generation Service. Please reference "Whitepaper:
         Linux* Stacks for Intel® Trust Domain Extensions (4.3 Attestation)" for
@@ -365,7 +365,7 @@ class TdxVM(ConfidentialVM):
         extraArgs: for TPM, it will be given list of IMR/PCRs
 
         Returns:
-            The ``Quote`` object.
+            The ``CcReport`` object. Return None if it fails.
 
         Raises:
             binascii.Error when the parameter "nonce" or "data" is not base64 encoded.

--- a/vmsdk/python/cctrusted_vm/sdk.py
+++ b/vmsdk/python/cctrusted_vm/sdk.py
@@ -98,9 +98,9 @@ class CCTrustedVmSdk(CCTrustedApi):
         data: bytearray = None,
         extraArgs = None
     ) -> CcReport:
-        """Get the quote for given nonce and data.
+        """Get the CcReport (i.e. quote) for given nonce and data.
 
-        The quote is signing of attestation data (IMR values or hashes of IMR
+        The CcReport is signing of attestation data (IMR values or hashes of IMR
         values), made by a trusted foundation (TPM) using a key trusted by the
         verifier.
 
@@ -112,7 +112,7 @@ class CCTrustedVmSdk(CCTrustedApi):
             extraArgs: for TPM, it will be given list of IMR/PCRs
 
         Returns:
-            The ``Quote`` object.
+            The ``CcReport`` object. Return None if it fails.
         """
         return self._cvm.get_cc_report(nonce, data, extraArgs)
 


### PR DESCRIPTION
1. Check the "Status Code" of TDG.VP.VMCALL<GetQuote> as spec.
2. Add parse for some field missed in previous code.