### PR TITLE
common: fix event encoding in python

### DIFF
--- a/common/python/cctrusted_base/eventlog.py
+++ b/common/python/cctrusted_base/eventlog.py
@@ -403,7 +403,7 @@ class EventLogs:
         rec_num = self._get_record_number(int(elements[imr_idx]))
 
         # Merge the elements left as event data
-        event = bytes(" ".join(elements[template_idx+1:]), "ascii")
+        event = bytes(" ".join(elements[template_idx+1:]), "utf-8")
         event_size = len(event)
 
         # Use digest size to figure out the algorithm id


### PR DESCRIPTION
Use 'utf-8' encoding instead of 'ascii' to fit special characters.